### PR TITLE
fix: fixes #21 loading phone numbers

### DIFF
--- a/src/js/getTwilioPhoneNumbers.js
+++ b/src/js/getTwilioPhoneNumbers.js
@@ -48,7 +48,9 @@ const getTwilioPhoneNumbersResursively = async (
   })
   const pages = [...accumulator, currentPage]
 
-  if (currentPage?.data?.next_page_uri) {
+  const nextPage = currentPage?.data?.next_page_uri
+  const phoneNumbersLength = currentPage?.data?.incoming_phone_numbers?.length ?? 0
+  if (nextPage && phoneNumbersLength > 0) {
     return getTwilioPhoneNumbersResursively(authentication, pageSize, pages)
   }
 


### PR DESCRIPTION
Add a condition to stop loading phone numbers when the current page has not results.

Twilio seem to have changed their API; or, they introduce a bug because their api always return a next_page_uri including when there are no next page.